### PR TITLE
Add Secure configuration option for MinIO client

### DIFF
--- a/cmd/cleanuser/main.go
+++ b/cmd/cleanuser/main.go
@@ -41,7 +41,7 @@ func main() {
 
 	client, err := minio.New(cfg.Endpoint, &minio.Options{
 		Creds:  credentials.NewStaticV4(cfg.AccessKey, cfg.SecretKey, ""),
-		Secure: true,
+		Secure: cfg.Secure,
 	})
 
 	if err != nil {

--- a/cmd/deletetranscript/main.go
+++ b/cmd/deletetranscript/main.go
@@ -31,7 +31,7 @@ func main() {
 
 	m, err := minio.New(cfg.Endpoint, &minio.Options{
 		Creds:  credentials.NewStaticV4(cfg.AccessKey, cfg.SecretKey, ""),
-		Secure: true,
+		Secure: cfg.Secure,
 	})
 
 	if err != nil {

--- a/cmd/exportguild/main.go
+++ b/cmd/exportguild/main.go
@@ -40,7 +40,7 @@ func main() {
 	// create minio client
 	m, err := minio.New(conf.Endpoint, &minio.Options{
 		Creds:  credentials.NewStaticV4(conf.AccessKey, conf.SecretKey, ""),
-		Secure: true,
+		Secure: conf.Secure,
 	})
 	if err != nil {
 		panic(err)

--- a/cmd/exportuser/main.go
+++ b/cmd/exportuser/main.go
@@ -129,7 +129,7 @@ func getTranscripts(conf config.Config, tickets map[uint64][]int) {
 	// create minio client
 	m, err := minio.New(conf.Endpoint, &minio.Options{
 		Creds:  credentials.NewStaticV4(conf.AccessKey, conf.SecretKey, ""),
-		Secure: true,
+		Secure: conf.Secure,
 	})
 	if err != nil {
 		panic(err)

--- a/cmd/fix-file-names/main.go
+++ b/cmd/fix-file-names/main.go
@@ -22,7 +22,7 @@ func main() {
 	// create minio client
 	client, err := minio.New(conf.Endpoint, &minio.Options{
 		Creds:  credentials.NewStaticV4(conf.AccessKey, conf.SecretKey, ""),
-		Secure: true,
+		Secure: conf.Secure,
 	})
 	if err != nil {
 		panic(err)

--- a/pkg/config/cliconfig.go
+++ b/pkg/config/cliconfig.go
@@ -5,4 +5,5 @@ type CliConfig struct {
 	SecretKey string `env:"S3_SECRET,required"`
 	Endpoint  string `env:"S3_ENDPOINT,required"`
 	Bucket    string `env:"S3_BUCKET,required"`
+	Secure    bool   `env:"S3_SECURE" envDefault:"true"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,6 +11,7 @@ type Config struct {
 
 	AccessKey       string    `env:"S3_ACCESS"`
 	SecretKey       string    `env:"S3_SECRET"`
+	Secure          bool      `env:"S3_SECURE" envDefault:"true"`
 	DefaultBucketId uuid.UUID `env:"DEFAULT_BUCKET_ID"`
 
 	SentryDsn      string `env:"SENTRY_DSN"`

--- a/pkg/s3client/clientmanager.go
+++ b/pkg/s3client/clientmanager.go
@@ -62,7 +62,7 @@ func (s *ShardedClientManager) Load(ctx context.Context) error {
 
 		m, err := minio.New(host, &minio.Options{
 			Creds:  credentials.NewStaticV4(s.config.AccessKey, s.config.SecretKey, ""),
-			Secure: true,
+			Secure: s.config.Secure,
 		})
 
 		if err != nil {


### PR DESCRIPTION
This PR adds a feature for users who do not want to deal with TLS with S3. *This is mostly a feature for self-hosted instances of the bot.*

This pull request introduces a configurable `Secure` option for MinIO clients, replacing the hardcoded `true` value with a dynamic configuration. This change allows the `Secure` setting to be toggled based on environment variables or configuration files, enhancing flexibility and adaptability across different environments.

### MinIO Client Configuration Updates:
* Replaced the hardcoded `Secure: true` with a dynamic `Secure` value derived from configuration objects in multiple files (`cmd/cleanuser/main.go`, `cmd/deletetranscript/main.go`, `cmd/exportguild/main.go`, `cmd/exportuser/main.go`, `cmd/fix-file-names/main.go`, and `pkg/s3client/clientmanager.go`). This enables the `Secure` flag to be configured per environment. [[1]](diffhunk://#diff-7cbf05e7b73cdf90dc6b2ba063a4889b1a68b42fb9efe4c558039cb19f0f8e4dL44-R44) [[2]](diffhunk://#diff-1942279e86d5b69169e700cd729e544f8fadb9abf6d1d986abb804beff0c7b1cL34-R34) [[3]](diffhunk://#diff-0faa32f6b4522e6e8d54321964ab94387ce59fbb79815f9c4336dc01cb01394bL43-R43) [[4]](diffhunk://#diff-d6cdba0929521c8553b62914c62bc36098ec00cd921601660168c394f97ccc90L132-R132) [[5]](diffhunk://#diff-8d1dd4e46b08c0408bcb6668ecf4a967604c7a1aa5afad73d32f7a7ee1f89318L25-R25) [[6]](diffhunk://#diff-a4e7688880691263d1f4a974b592927073be08b585451e00a7b38e0cfbc92242L65-R65)

### Configuration Struct Enhancements:
* Added a `Secure` field to the `CliConfig` struct in `pkg/config/cliconfig.go`, with an environment variable `S3_SECURE` and a default value of `true`.
* Added a `Secure` field to the `Config` struct in `pkg/config/config.go`, with an environment variable `S3_SECURE` and a default value of `true`.

## More Pull Requests
- https://github.com/TicketsBot-cloud/import-sync/pull/3
- https://github.com/TicketsBot-cloud/dashboard/pull/10