### PR TITLE
RM-220: Refactor guild purge to bulk delete objects and DB records

### DIFF
--- a/internal/removequeue.go
+++ b/internal/removequeue.go
@@ -30,6 +30,7 @@ const (
 	StatusInProgress Status = "in_progress"
 	StatusComplete   Status = "complete"
 	StatusFailed     Status = "failed"
+	StatusTimeout    Status = "timeout"
 )
 
 var (
@@ -130,21 +131,25 @@ func (q *RemoveQueue) StartReaper() {
 
 		q.mu.Lock()
 		for guildId, operation := range q.queue {
-			if operation.LastUpdated.Before(time.Now().Add(-10 * time.Minute)) {
-				if operation.Status == StatusInProgress {
-					q.logger.Warn(
-						"Removing in-progress operation from queue due to lack of updates",
-						zap.Uint64("guild", guildId),
-						zap.String("status", string(operation.Status)),
-					)
-				} else {
-					q.logger.Debug(
-						"Removing completed operation from queue",
-						zap.Uint64("guild", guildId),
-						zap.String("status", string(operation.Status)),
-					)
-				}
+			timeSinceUpdate := time.Since(operation.LastUpdated)
 
+			if operation.Status == StatusInProgress && timeSinceUpdate >= 10*time.Minute {
+				// Operation stuck, mark as timeout instead of deleting
+				operation.Status = StatusTimeout
+				operation.LastUpdated = time.Now()
+				q.queue[guildId] = operation
+
+				q.logger.Warn(
+					"Operation timed out after inactivity",
+					zap.Uint64("guild", guildId),
+				)
+			} else if (operation.Status == StatusComplete || operation.Status == StatusFailed || operation.Status == StatusTimeout) && timeSinceUpdate >= 10*time.Minute {
+				// Clean up completed/failed/timeout statuses
+				q.logger.Debug(
+					"Removing completed operation from queue",
+					zap.Uint64("guild", guildId),
+					zap.String("status", string(operation.Status)),
+				)
 				delete(q.queue, guildId)
 			}
 		}

--- a/pkg/http/purgeguild.go
+++ b/pkg/http/purgeguild.go
@@ -6,13 +6,12 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"strings"
-	"sync"
 
 	"github.com/TicketsBot-cloud/logarchiver/internal"
 	"github.com/TicketsBot-cloud/logarchiver/pkg/repository"
 	"github.com/TicketsBot-cloud/logarchiver/pkg/repository/model"
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/minio/minio-go/v7"
 	"go.uber.org/zap"
 )
@@ -23,17 +22,6 @@ func (s *Server) purgeGuildHandler(ctx *gin.Context) {
 		ctx.JSON(400, gin.H{
 			"success": false,
 			"message": "missing guild ID",
-		})
-		return
-	}
-
-	defaultClient, err := s.s3Clients.Get(s.Config.DefaultBucketId)
-	if err != nil {
-		s.Logger.Error("Failed to get default S3 client", zap.Error(err), zap.String("bucket_id", s.Config.DefaultBucketId.String()))
-
-		ctx.JSON(500, gin.H{
-			"success": false,
-			"message": "Failed to get default S3 client",
 		})
 		return
 	}
@@ -50,126 +38,117 @@ func (s *Server) purgeGuildHandler(ctx *gin.Context) {
 				"message": err.Error(),
 			})
 		}
-
 		return
 	}
 
-	type record struct {
-		model.Object
-		Key string
-	}
-
-	removeCh := make(chan record)
 	go func() {
-		var errCount int
-		for r := range removeCh {
-			client, err := s.s3Clients.Get(r.BucketId)
-			if err != nil {
-				s.Logger.Error("Failed to get S3 client", zap.Error(err), zap.String("bucket_id", r.BucketId.String()))
-				continue
-			}
+		prefix := fmt.Sprintf("%d/", guildId)
+		totalDeleted := 0
+		var firstErr error
 
-			if err := client.Minio().RemoveObject(context.Background(), client.BucketName(), r.Key, minio.RemoveObjectOptions{}); err != nil {
-				s.RemoveQueue.AddError(guildId, r.Key, err)
+		// Get all unique bucket IDs (default + any from database)
+		bucketIds := make(map[string]struct{})
+		bucketIds[s.Config.DefaultBucketId.String()] = struct{}{}
 
-				s.Logger.Error(
-					"Failed to remove object",
-					zap.Error(err),
-					zap.String("object", r.Key),
-					zap.Uint64("guild", guildId),
-				)
-
-				errCount++
-			}
-		}
-
-		if errCount > 0 {
-			s.RemoveQueue.SetStatus(guildId, internal.StatusFailed)
-			s.Logger.Warn(
-				"Remove operation completed with error(s)",
-				zap.Int("error_count", errCount),
-				zap.Uint64("guild", guildId),
-			)
-		} else {
-			s.RemoveQueue.SetStatus(guildId, internal.StatusComplete)
-			s.Logger.Info("Remove operation completed successfully", zap.Uint64("guild", guildId))
-		}
-	}()
-
-	// For the default bucket, we'll have to list all objects. For new buckets, we can fetch a list of objects from
-	// the database.
-
-	latch := sync.WaitGroup{}
-	latch.Add(2)
-
-	// Fetch from the default bucket
-	go func() {
-		objCh := defaultClient.Minio().ListObjects(context.Background(), defaultClient.BucketName(), minio.ListObjectsOptions{
-			Prefix:    fmt.Sprintf("%d/", guildId),
-			Recursive: true,
-		})
-
-		for obj := range objCh {
-			s.Logger.Info(
-				"Found object to remove",
-				zap.String("object", obj.Key),
-				zap.Uint64("guild", guildId),
-			)
-
-			// Parse ticket ID, in form guildId/ticketId or guildId/free-ticketId
-			cut := obj.Key[len(fmt.Sprintf("%d/", guildId)):]
-			if strings.HasPrefix(cut, "free-") {
-				cut = cut[len("free-"):]
-			}
-
-			ticketId, err := strconv.Atoi(cut)
-			if err != nil {
-				s.Logger.Error("Failed to parse ticket ID", zap.Error(err), zap.String("object", obj.Key), zap.Uint64("guild", guildId))
-				s.RemoveQueue.AddError(guildId, obj.Key, err)
-				continue
-			}
-
-			s.RemoveQueue.AddRemovedObject(guildId, obj.Key)
-			removeCh <- record{
-				Object: model.Object{
-					GuildId:  guildId,
-					TicketId: ticketId,
-					BucketId: s.Config.DefaultBucketId,
-				},
-				Key: obj.Key,
-			}
-		}
-
-		latch.Done()
-	}()
-
-	// Fetch from the database
-	go func() {
-		var objects []model.Object
+		// Add bucket IDs from database
+		var dbObjects []model.Object
 		if err := s.store.Tx(context.Background(), func(r repository.Repositories) (err error) {
-			objects, err = r.Objects().ListByGuild(context.Background(), guildId)
+			dbObjects, err = r.Objects().ListByGuild(context.Background(), guildId)
 			return
 		}); err != nil {
 			s.Logger.Error("Failed to fetch objects from database", zap.Error(err), zap.Uint64("guild", guildId))
-			return
-		}
-
-		for _, obj := range objects {
-			s.Logger.Debug("Found object to remove", zap.String("bucket", obj.BucketId.String()), zap.Uint64("guild", guildId), zap.Int("ticket_id", obj.TicketId))
-			s.RemoveQueue.AddRemovedObject(guildId, obj.S3Key())
-			removeCh <- record{
-				Object: obj,
-				Key:    obj.S3Key(),
+			firstErr = err
+		} else {
+			for _, obj := range dbObjects {
+				bucketIds[obj.BucketId.String()] = struct{}{}
 			}
 		}
 
-		latch.Done()
-	}()
+		// Delete from each bucket
+		for bucketIdStr := range bucketIds {
+			s.Logger.Debug("Processing bucket", zap.String("bucket_id", bucketIdStr), zap.Uint64("guild", guildId))
 
-	// Close the remove channel when both goroutines have completed
-	go func() {
-		latch.Wait()
-		close(removeCh)
+			bucketId, err := uuid.Parse(bucketIdStr)
+			if err != nil {
+				s.Logger.Error("Failed to parse bucket ID", zap.Error(err), zap.String("bucket_id", bucketIdStr), zap.Uint64("guild", guildId))
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
+			}
+
+			client, err := s.s3Clients.Get(bucketId)
+			if err != nil {
+				s.Logger.Error("Failed to get S3 client", zap.Error(err), zap.String("bucket_id", bucketIdStr), zap.Uint64("guild", guildId))
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
+			}
+
+			s.Logger.Debug("Listing objects", zap.String("bucket", client.BucketName()), zap.String("prefix", prefix), zap.Uint64("guild", guildId))
+
+			// List all objects with guild prefix
+			objectCh := client.Minio().ListObjects(context.Background(), client.BucketName(), minio.ListObjectsOptions{
+				Prefix:    prefix,
+				Recursive: true,
+			})
+
+			// Create channel for RemoveObjects
+			objectsCh := make(chan minio.ObjectInfo)
+
+			bucketObjectCount := 0
+			go func() {
+				defer close(objectsCh)
+				for obj := range objectCh {
+					if obj.Err != nil {
+						s.Logger.Warn("Error listing object (non-fatal)", zap.Error(obj.Err), zap.Uint64("guild", guildId))
+						continue
+					}
+					bucketObjectCount++
+					objectsCh <- obj
+				}
+				s.Logger.Debug("Finished listing objects", zap.Int("count", bucketObjectCount), zap.Uint64("guild", guildId))
+			}()
+
+			// Bulk delete
+			bucketDeletedCount := 0
+			for result := range client.Minio().RemoveObjects(context.Background(), client.BucketName(), objectsCh, minio.RemoveObjectsOptions{}) {
+				if result.Err != nil {
+					s.Logger.Error("Failed to remove object", zap.Error(result.Err), zap.String("object", result.ObjectName), zap.Uint64("guild", guildId))
+					if firstErr == nil {
+						firstErr = result.Err
+					}
+				} else {
+					bucketDeletedCount++
+					totalDeleted++
+				}
+			}
+
+			s.Logger.Debug("Finished deleting from bucket", zap.Int("deleted", bucketDeletedCount), zap.String("bucket_id", bucketIdStr), zap.Uint64("guild", guildId))
+		}
+
+		// Delete database records
+		if err := s.store.Tx(context.Background(), func(r repository.Repositories) error {
+			return r.Objects().DeleteByGuild(context.Background(), guildId)
+		}); err != nil {
+			s.Logger.Error("Failed to delete objects from database", zap.Error(err), zap.Uint64("guild", guildId))
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+
+		if firstErr != nil {
+			s.RemoveQueue.SetStatus(guildId, internal.StatusFailed)
+			s.Logger.Error("Remove operation failed", zap.Error(firstErr), zap.Uint64("guild", guildId), zap.Int("deleted", totalDeleted))
+		} else {
+			s.RemoveQueue.SetStatus(guildId, internal.StatusComplete)
+			if totalDeleted == 0 {
+				s.Logger.Info("Remove operation completed - no transcripts to delete", zap.Uint64("guild", guildId))
+			} else {
+				s.Logger.Info("Remove operation completed successfully", zap.Uint64("guild", guildId), zap.Int("deleted", totalDeleted))
+			}
+		}
 	}()
 
 	ctx.JSON(http.StatusAccepted, gin.H{

--- a/pkg/repository/postgresobjects.go
+++ b/pkg/repository/postgresobjects.go
@@ -27,6 +27,9 @@ var (
 
 	//go:embed sql/objects/delete.sql
 	queryDeleteObject string
+
+	//go:embed sql/objects/delete_by_guild.sql
+	queryDeleteByGuild string
 )
 
 func newPostgresObjectRepository(tx pgx.Tx) *PostgresObjectRepository {
@@ -79,6 +82,14 @@ func (p *PostgresObjectRepository) CreateObject(ctx context.Context, object mode
 
 func (p *PostgresObjectRepository) DeleteObject(ctx context.Context, guildId uint64, ticketId int) error {
 	if _, err := p.tx.Exec(ctx, queryDeleteObject, guildId, ticketId); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *PostgresObjectRepository) DeleteByGuild(ctx context.Context, guildId uint64) error {
+	if _, err := p.tx.Exec(ctx, queryDeleteByGuild, guildId); err != nil {
 		return err
 	}
 

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -29,4 +29,5 @@ type ObjectRepository interface {
 	CreateObject(ctx context.Context, object model.Object) error
 	ListByGuild(ctx context.Context, guildId uint64) ([]model.Object, error)
 	DeleteObject(ctx context.Context, guildId uint64, ticketId int) error
+	DeleteByGuild(ctx context.Context, guildId uint64) error
 }

--- a/pkg/repository/sql/objects/delete_by_guild.sql
+++ b/pkg/repository/sql/objects/delete_by_guild.sql
@@ -1,0 +1,2 @@
+DELETE FROM objects
+WHERE "guild_id" = $1;


### PR DESCRIPTION
RM-220
Reworks the purgeGuildHandler to efficiently bulk delete all S3 objects for a guild across all buckets and remove corresponding database records in a single operation. Adds a DeleteByGuild method and SQL query to the repository for deleting all objects by guild ID. Enhances the remove queue reaper to mark stuck operations as timed out and clean up completed, failed, or timed out operations after a set period.

For: https://github.com/TicketsBot-cloud/cleanupdaemon/pull/2